### PR TITLE
add func to read burnSoFarSet[pubKeyTokenIdHash] from NoriTokenBridge.sol

### DIFF
--- a/core/src/eth_2.rs
+++ b/core/src/eth_2.rs
@@ -284,6 +284,44 @@ pub async fn get_chain_state_hashes(
         .map_err(|_| EthError::SerializationError("wrong number of state hashes from contract".into()))
 }
 
+/// Decodes `encoded_account` (ABI-encoded `MinaAccountValidationExample::Account`) and
+/// computes the `burnSoFarSet` mapping key used in `NoriTokenBridge.sol`:
+/// `uint256(keccak256(abi.encode(account.publicKey, account.tokenIdKeyHash)))`.
+pub fn compute_pub_key_token_id_hash(encoded_account: &[u8]) -> Result<U256, EthError> {
+    use alloy::sol_types::SolValue;
+    let account = MinaAccountValidationExample::Account::abi_decode(encoded_account)
+        .map_err(|e| EthError::SerializationError(format!("failed to ABI-decode encoded_account: {e}")))?;
+    let key_bytes = (account.publicKey, account.tokenIdKeyHash).abi_encode();
+    let hash = alloy::primitives::keccak256(&key_bytes);
+    Ok(U256::from_be_bytes(hash.0))
+}
+
+/// Decodes `encoded_account` and extracts `zkapp.appState[2]` as a big-endian `U256`.
+/// `appState[2]` stores the cumulative burn amount recorded by the Mina zkapp.
+pub fn extract_mina_burn_so_far(encoded_account: &[u8]) -> Result<U256, EthError> {
+    use alloy::sol_types::SolValue;
+    let account = MinaAccountValidationExample::Account::abi_decode(encoded_account)
+        .map_err(|e| EthError::SerializationError(format!("failed to ABI-decode encoded_account: {e}")))?;
+    Ok(U256::from_be_bytes(account.zkapp.appState[2].0))
+}
+
+/// Reads `burnSoFarSet[pubKeyTokenIdHash]` from `NoriTokenBridge.sol`.
+/// Pure view call — no wallet needed.
+pub async fn get_burn_so_far(
+    pub_key_token_id_hash: U256,
+    eth_rpc_url: &Url,
+    nori_token_bridge_addr: Address,
+) -> Result<U256, EthError> {
+    let provider = ProviderBuilder::new().connect_http(eth_rpc_url.clone());
+    let contract = NoriTokenBridge::new(nori_token_bridge_addr, provider);
+    let result = contract
+        .burnSoFarSet(pub_key_token_id_hash)
+        .call()
+        .await
+        .map_err(classify_contract_call_error)?;
+    Ok(result)
+}
+
 /// Checks a mined receipt for success or failure.
 ///
 /// Call this after `get_tx_receipt` returns `Some(receipt)`.

--- a/core/src/rpcs/errors.rs
+++ b/core/src/rpcs/errors.rs
@@ -669,6 +669,21 @@ impl fmt::Display for EthError {
 
 impl std::error::Error for EthError {}
 
+impl EthError {
+    /// Returns `true` for errors that are transient and worth retrying with backoff.
+    /// Returns `false` for permanent failures where retrying would waste gas or indicate
+    /// a code/config bug.
+    pub fn is_retryable(&self) -> bool {
+        matches!(
+            self,
+            EthError::RpcUnreachable(_)
+                | EthError::NonceCollision(_)
+                | EthError::UnexpectedRpcResponse(_)
+                | EthError::GasSafetyLimit(_)
+        )
+    }
+}
+
 // AccountIsNotValid is defined in MinaStateSettlementExample.sol but absent from
 // the ABI JSON (used internally via cross-contract call). Define it here so
 // alloy::sol! generates a type with the correct selector for revert decoding.

--- a/core/src/rpcs/eth.rs
+++ b/core/src/rpcs/eth.rs
@@ -102,6 +102,17 @@ impl EthRPC {
         eth_2::get_tx_receipt(&self.eth_rpc_url, tx_hash).await
     }
 
+    /// Reads `burnSoFarSet[pubKeyTokenIdHash]` from `NoriTokenBridge.sol`.
+    /// Pure view call — no wallet needed.
+    pub async fn get_burn_so_far(&self, pub_key_token_id_hash: U256) -> Result<U256, EthError> {
+        eth_2::get_burn_so_far(
+            pub_key_token_id_hash,
+            &self.eth_rpc_url,
+            self.nori_token_bridge_address,
+        )
+        .await
+    }
+
     /// Reads the chain state hashes from `MinaStateSettlement.sol`.
     pub async fn get_chain_state_hashes(
         &self,


### PR DESCRIPTION
## Context

Worker-`NoriBridgeEthUnlocker` ([nori_aligned_services](https://github.com/Nori-zk/nori_aligned_services/)) needs these during crash recovery to check whether a `NoriEthUnlockReady` burn was already processed on-chain before re-submitting. The crash window is: process dies after `send_unlock_tokens` broadcasts the tx but before `checkpoint_unlock_sent` writes `NoriEthUnlockSent` to MongoDB. On restart the burn is still at `NoriEthUnlockReady`; without this check the worker would re-submit a tx the contract would revert with `"Burn so far is greater than the amount to burn"`.

The check compares `encoded_account.appState[2]` (what the proof covers) against the live `burnSoFarSet[hash]`. If the gap is 0 the on-chain state already reflects this burn and re-submission is skipped.